### PR TITLE
Switch from Hot Bunnies to March Hare

### DIFF
--- a/frenzy_bunnies.gemspec
+++ b/frenzy_bunnies.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FrenzyBunnies::VERSION
   
-  gem.add_runtime_dependency 'hot_bunnies', '>= 1.4.0.pre3'
+  gem.add_runtime_dependency 'march_hare', '>= 2.0.0.rc3'
   gem.add_runtime_dependency 'thor'
   gem.add_runtime_dependency 'sinatra'
   gem.add_runtime_dependency 'atomic'


### PR DESCRIPTION
The `HotBunnies` module should still be available as
an alias.
