### PR TITLE
Support other exchange types and routing keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ In your worker class, say `from_queue 'queue_name'` and pass any of these option
 :durable   # default false. durability of the queue
 :timeout_job_after # default 5. reject the message if not processed for number of seconds
 :threads  # default none. number of threads in the threadpool. leave empty to let the threadpool manage it.
-:type # default :direct. type of exchange used.
+:exchange_type # default :direct. type of exchange used.
 :routing_key # default queue_name. allows for other routing keys, useful for topic exchanges.
 ```
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ In your worker class, say `from_queue 'queue_name'` and pass any of these option
 :durable   # default false. durability of the queue
 :timeout_job_after # default 5. reject the message if not processed for number of seconds
 :threads  # default none. number of threads in the threadpool. leave empty to let the threadpool manage it.
+:type # default :direct. type of exchange used.
+:routing_key # default queue_name. allows for other routing keys, useful for topic exchanges.
 ```
 
 Example:

--- a/README.md
+++ b/README.md
@@ -103,12 +103,13 @@ context definitions
 In your worker class, say `from_queue 'queue_name'` and pass any of these options:
 
 ```ruby
+:exchange # default frenzy_bunnies. name of exchange.
+:exchange_type # default :direct. type of exchange used.
+:routing_key # default queue_name. allows for other routing keys, useful for topic exchanges.
 :prefetch  # default 10. number of messages to prefetch each time
 :durable   # default false. durability of the queue
 :timeout_job_after # default 5. reject the message if not processed for number of seconds
 :threads  # default none. number of threads in the threadpool. leave empty to let the threadpool manage it.
-:exchange_type # default :direct. type of exchange used.
-:routing_key # default queue_name. allows for other routing keys, useful for topic exchanges.
 ```
 
 Example:
@@ -128,7 +129,6 @@ Global / running configuration can be set through the running context `FrenzyBun
 
 ```ruby
 :host       # default 'localhost'
-:exchange   # default 'frenzy_bunnies'
 :heartbeat  # default 5
 :web_host   # default 'localhost'
 :web_port   # default 11333
@@ -140,7 +140,7 @@ Global / running configuration can be set through the running context `FrenzyBun
 Example:
 
 ```ruby
-FrenzyBunnies::Context.new :exchange=> 'foo'
+FrenzyBunnies::Context.new :heartbeat => 10
 ```
 
 ### AMQP Queue Wiring Under the Hood

--- a/lib/frenzy_bunnies/context.rb
+++ b/lib/frenzy_bunnies/context.rb
@@ -7,7 +7,6 @@ class FrenzyBunnies::Context
   def initialize(opts={})
     @opts = opts
     @opts[:host]     ||= 'localhost'
-    @opts[:exchange] ||= 'frenzy_bunnies'
     @opts[:heartbeat] ||= 5
     @opts[:web_host] ||= 'localhost'
     @opts[:web_port] ||= 11333
@@ -22,7 +21,7 @@ class FrenzyBunnies::Context
     @connection = HotBunnies.connect(params)
     @connection.add_shutdown_listener(lambda { |cause| @logger.error("Disconnected: #{cause}"); stop;})
 
-    @queue_factory = FrenzyBunnies::QueueFactory.new(@connection, @opts[:exchange])
+    @queue_factory = FrenzyBunnies::QueueFactory.new(@connection)
   end
 
   def run(*klasses)

--- a/lib/frenzy_bunnies/queue_factory.rb
+++ b/lib/frenzy_bunnies/queue_factory.rb
@@ -1,19 +1,19 @@
 class FrenzyBunnies::QueueFactory
-  def initialize(connection, exchange)
+  def initialize(connection)
     @connection = connection
-    @exchange = exchange
   end
 
   def build_queue(name, options)
-    durable = options[:durable]
-    prefetch = options[:prefetch]
+    exchange_name = options[:exchange] || 'frenzy_bunnies'
     exchange_type = options[:exchange_type] || :direct
     routing_key = options[:routing_key] || name
+    durable = options[:durable]
+    prefetch = options[:prefetch]
 
     channel = @connection.create_channel
     channel.prefetch = prefetch
 
-    exchange = channel.exchange(@exchange, :type => exchange_type, :durable => durable)
+    exchange = channel.exchange(exchange_name, :type => exchange_type, :durable => durable)
 
     queue = channel.queue(name, :durable => durable)
     queue.bind(exchange, :routing_key => routing_key)

--- a/lib/frenzy_bunnies/queue_factory.rb
+++ b/lib/frenzy_bunnies/queue_factory.rb
@@ -7,13 +7,13 @@ class FrenzyBunnies::QueueFactory
   def build_queue(name, options)
     durable = options[:durable]
     prefetch = options[:prefetch]
-    type = options[:type] || :direct
+    exchange_type = options[:exchange_type] || :direct
     routing_key = options[:routing_key] || name
 
     channel = @connection.create_channel
     channel.prefetch = prefetch
 
-    exchange = channel.exchange(@exchange, :type => type, :durable => durable)
+    exchange = channel.exchange(@exchange, :type => exchange_type, :durable => durable)
 
     queue = channel.queue(name, :durable => durable)
     queue.bind(exchange, :routing_key => routing_key)

--- a/lib/frenzy_bunnies/queue_factory.rb
+++ b/lib/frenzy_bunnies/queue_factory.rb
@@ -4,14 +4,19 @@ class FrenzyBunnies::QueueFactory
     @exchange = exchange
   end
 
-  def build_queue(name, prefetch, durable)
+  def build_queue(name, options)
+    durable = options[:durable]
+    prefetch = options[:prefetch]
+    type = options[:type] || :direct
+    routing_key = options[:routing_key] || name
+
     channel = @connection.create_channel
     channel.prefetch = prefetch
 
-    exchange = channel.exchange(@exchange, :type => :direct, :durable => durable)
+    exchange = channel.exchange(@exchange, :type => type, :durable => durable)
 
     queue = channel.queue(name, :durable => durable)
-    queue.bind(exchange, :routing_key => name)
+    queue.bind(exchange, :routing_key => routing_key)
     queue
   end
 end

--- a/lib/frenzy_bunnies/worker.rb
+++ b/lib/frenzy_bunnies/worker.rb
@@ -41,7 +41,7 @@ module FrenzyBunnies::Worker
         @thread_pool = Executors.new_cached_thread_pool
       end
 
-      q = context.queue_factory.build_queue(queue_name, @queue_opts[:prefetch], @queue_opts[:durable])
+      q = context.queue_factory.build_queue(queue_name, @queue_opts)
       @s = q.subscribe(:ack => true)
 
       say "#{@queue_opts[:threads] ? "#{@queue_opts[:threads]} threads " : ''}with #{@queue_opts[:prefetch]} prefetch on <#{queue_name}>."

--- a/spec/frenzy_bunnies/worker_spec.rb
+++ b/spec/frenzy_bunnies/worker_spec.rb
@@ -22,7 +22,7 @@ def with_test_queuefactory(ctx, ack=true, msg=nil, nowork=false)
   q = Object.new
   s = Object.new
   hdr = Object.new
-  mock(qf).build_queue(anything, anything, anything) { q }
+  mock(qf).build_queue(anything, anything) { q }
   mock(q).subscribe(anything){ s }
 
   mock(s).each(anything) { |h,b| b.call(hdr, msg) unless nowork }


### PR DESCRIPTION
This allows topic exchanges with routing keys not based off of names. It goes further than the other pull request with routing keys.
