### PR TITLE
Allows to set parameter `vhost` when creating a Context

### DIFF
--- a/lib/frenzy_bunnies/context.rb
+++ b/lib/frenzy_bunnies/context.rb
@@ -6,10 +6,10 @@ class FrenzyBunnies::Context
 
   def initialize(opts={})
     @opts = opts
-    @opts[:host]     ||= 'localhost'
+    @opts[:host]      ||= 'localhost'
     @opts[:heartbeat] ||= 5
-    @opts[:web_host] ||= 'localhost'
-    @opts[:web_port] ||= 11333
+    @opts[:web_host]  ||= 'localhost'
+    @opts[:web_port]  ||= 11333
     @opts[:web_threadfilter] ||= /^pool-.*/
     @opts[:env] ||= 'development'
 
@@ -18,6 +18,7 @@ class FrenzyBunnies::Context
     params = {:host => @opts[:host], :heartbeat_interval => @opts[:heartbeat]}
     (params[:username], params[:password] = @opts[:username], @opts[:password]) if @opts[:username] && @opts[:password]
     (params[:port] = @opts[:port]) if @opts[:port]
+    (params[:vhost] = @opts[:vhost]) if @opts[:vhost]
     @connection = MarchHare.connect(params)
     @connection.add_shutdown_listener(lambda { |cause| @logger.error("Disconnected: #{cause}"); stop;})
 


### PR DESCRIPTION
This PR allows to provide the `vhost` parameter as an argument to the `MarchHare.connect` function.
